### PR TITLE
Use go.mercari.io for import path

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # go-httpdoc [![Go Documentation](http://img.shields.io/badge/go-documentation-blue.svg?style=flat-square)][godoc] [![Travis](https://img.shields.io/travis/mercari/go-httpdoc.svg?style=flat-square)][travis] [![Codecov](https://img.shields.io/codecov/c/github/mercari/go-httpdoc.svg?style=flat-square)][codecov]
 
-[godoc]: http://godoc.org/github.com/mercari/go-httpdoc
+[godoc]: http://godoc.org/go.mercari.io/go-httpdoc
 [travis]: https://travis-ci.org/mercari/go-httpdoc
 [codecov]: https://codecov.io/gh/mercari/go-httpdoc
 
@@ -10,7 +10,7 @@ It provides a simple http middleware which records http requests and responses f
 
 Not only JSON request and response but it also supports [protocol buffer](https://developers.google.com/protocol-buffers/). See [Sample ProtoBuf Documentation](/_example/doc/protobuf.md)).
 
-See usage and example in [GoDoc](https://godoc.org/github.com/mercari/go-httpdoc).
+See usage and example in [GoDoc](https://godoc.org/go.mercari.io/go-httpdoc).
 
 *NOTE*: This package is experimental and may make backward-incompatible changes.
 
@@ -24,7 +24,7 @@ $ go get -u go.mercari.io/go-httpdoc
 
 ## Usage
 
-All usage are described in [GoDoc](https://godoc.org/github.com/mercari/go-httpdoc).
+All usage are described in [GoDoc](https://godoc.org/go.mercari.io/go-httpdoc).
 
 To generate documentation, set the following env var:
 

--- a/_example/handler_proto_test.go
+++ b/_example/handler_proto_test.go
@@ -5,7 +5,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	httpdoc "github.com/mercari/go-httpdoc"
+	httpdoc "go.mercari.io/go-httpdoc"
 )
 
 func TestUserHandlerWithProtobuf(t *testing.T) {

--- a/_example/handler_simple_test.go
+++ b/_example/handler_simple_test.go
@@ -7,7 +7,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	httpdoc "github.com/mercari/go-httpdoc"
+	httpdoc "go.mercari.io/go-httpdoc"
 )
 
 func TestUserHandlerSimple(t *testing.T) {

--- a/_example/handler_validate_test.go
+++ b/_example/handler_validate_test.go
@@ -5,7 +5,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	httpdoc "github.com/mercari/go-httpdoc"
+	httpdoc "go.mercari.io/go-httpdoc"
 )
 
 func TestUserHandlerWithValidate(t *testing.T) {

--- a/doc.go
+++ b/doc.go
@@ -6,4 +6,4 @@
 // params or response fields).
 //
 // See example document output, https://github.com/mercari/go-httpdoc/blob/master/_example/doc/validate.md
-package httpdoc
+package httpdoc // import "go.mercari.io/go-httpdoc"

--- a/template.go
+++ b/template.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/mercari/go-httpdoc/static"
+	"go.mercari.io/go-httpdoc/static"
 )
 
 // defaultTmpl is default template file to use.


### PR DESCRIPTION
Use go.mercari.io for import path.

---

First, congrats released go.mercari.io :tada:

BTW, current go-httpdoc uses "github.com/mercari/go-httpdoc" import path on `template.go` or etc. So, if some users installed go-httpdoc along the README, will create two directories in `$GOPATH/src`.
e.g.:

```sh
> GOPATH=$PWD go get -u go.mercari.io/go-httpdoc
> ls
pkg src
> ls src/github.com/mercari
go-httpdoc
> ls src/go.mercari.io
go-httpdoc
```

signed CLA.
Thanks.