### PR TITLE
Add space after equal

### DIFF
--- a/proto/message.proto
+++ b/proto/message.proto
@@ -15,5 +15,5 @@ message UserProtoResponse {
   int32 id = 1;
   string name = 2;
   bool active = 3;
-  Setting setting =4;
+  Setting setting = 4;
 }


### PR DESCRIPTION
`protoc` can parses current syntax, but more human readable.