### PR TITLE
Support go1.6 runtime

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: go
 go:
+  - 1.6.x
   - 1.8.3
   - tip
 

--- a/httpdoc.go
+++ b/httpdoc.go
@@ -194,8 +194,10 @@ func Record(next http.Handler, document *Document, opt *RecordOption) http.Handl
 
 				var buf bytes.Buffer
 				encoder := json.NewEncoder(&buf)
-				encoder.SetIndent("", "  ")
 				encoder.Encode(unmarshaler)
+				s := buf.String()
+				buf.Reset()
+				json.Indent(&buf, []byte(s), "", "  ")
 
 				requestExample = buf.String()
 			}
@@ -205,8 +207,10 @@ func Record(next http.Handler, document *Document, opt *RecordOption) http.Handl
 
 				var buf bytes.Buffer
 				encoder := json.NewEncoder(&buf)
-				encoder.SetIndent("", "  ")
 				encoder.Encode(unmarshaler)
+				s := buf.String()
+				buf.Reset()
+				json.Indent(&buf, []byte(s), "", "  ")
 
 				responseExample = buf.String()
 			}

--- a/httpdoc.go
+++ b/httpdoc.go
@@ -118,6 +118,12 @@ type Data struct {
 	Description string
 }
 
+type byName []Data
+
+func (n byName) Len() int           { return len(n) }
+func (n byName) Less(i, j int) bool { return n[i].Name < n[j].Name }
+func (n byName) Swap(i, j int)      { n[i], n[j] = n[j], n[i] }
+
 // Record is a http middleware. It records all request & response values which the given http handler
 // receives & response and save it in the given Document.
 func Record(next http.Handler, document *Document, opt *RecordOption) http.Handler {
@@ -229,13 +235,8 @@ func Record(next http.Handler, document *Document, opt *RecordOption) http.Handl
 
 // format sorts entry data to prevent results updated everytime.
 func (e *Entry) format() error {
-	sort.Slice(e.RequestHeaders, func(i, j int) bool {
-		return e.RequestHeaders[i].Name < e.RequestHeaders[j].Name
-	})
-
-	sort.Slice(e.RequestParams, func(i, j int) bool {
-		return e.RequestParams[i].Name < e.RequestParams[j].Name
-	})
+	sort.Sort(byName(e.RequestHeaders))
+	sort.Sort(byName(e.RequestParams))
 
 	return nil
 }

--- a/httpdoc_test.go
+++ b/httpdoc_test.go
@@ -281,9 +281,7 @@ func TestConvertHeaders(t *testing.T) {
 		},
 	}
 
-	sort.Slice(got, func(i, j int) bool {
-		return got[i].Name < got[j].Name
-	})
+	sort.Sort(byName(got))
 
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("got %#v, want %#v", got, want)


### PR DESCRIPTION
go1.6 hasn't `sort.Slice` and `json.Encoder.SetIndent` method.
Support go1.6 such as Google App Engine.