### PR TITLE
Add MkdirAll if not exist output directory

### DIFF
--- a/template.go
+++ b/template.go
@@ -23,6 +23,11 @@ func (d *Document) Generate(path string) error {
 	}
 
 	path, _ = filepath.Abs(path)
+	if _, err := os.Stat(filepath.Dir(path)); err != nil && os.IsNotExist(err) {
+		if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+			return err
+		}
+	}
 	f, err := os.Create(path)
 	if err != nil {
 		return err

--- a/template_test.go
+++ b/template_test.go
@@ -80,14 +80,15 @@ func TestFuncMap(t *testing.T) {
 	}
 }
 
-func TestTemplateGenerate_InvalidPath(t *testing.T) {
+func TestTemplateGenerate_NotExistDir(t *testing.T) {
 	resetF := setEnv(t, EnvHTTPDoc, "1")
 	defer resetF()
 
 	doc := &Document{}
-	if err := doc.Generate("/tmp/httpdoc/no-such-file-or-directory"); err == nil {
+	if err := doc.Generate("/tmp/httpdoc/no-such-file-or-directory"); err != nil {
 		t.Fatalf("expect to be failed")
 	}
+	defer os.RemoveAll("/tmp/httpdoc")
 }
 
 func TestTemplateGenerate_InvalidTmpl(t *testing.T) {


### PR DESCRIPTION
Add `os.MkdirAll` if not exist output directory.

In case of `httpdoc.Generate("doc/simple.md")`, will fail if not exist output(`doc`) directory.