### PR TITLE
Fix travis badge to always show master branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# go-httpdoc [![Go Documentation](http://img.shields.io/badge/go-documentation-blue.svg?style=flat-square)][godoc] [![Travis](https://img.shields.io/travis/mercari/go-httpdoc.svg?style=flat-square)][travis] [![Codecov](https://img.shields.io/codecov/c/github/mercari/go-httpdoc.svg?style=flat-square)][codecov]
+# go-httpdoc [![Go Documentation](http://img.shields.io/badge/go-documentation-blue.svg?style=flat-square)][godoc] [![Travis](https://img.shields.io/travis/mercari/go-httpdoc/master.svg?style=flat-square)][travis] [![Codecov](https://img.shields.io/codecov/c/github/mercari/go-httpdoc.svg?style=flat-square)][codecov]
 
 [godoc]: http://godoc.org/go.mercari.io/go-httpdoc
 [travis]: https://travis-ci.org/mercari/go-httpdoc


### PR DESCRIPTION
If not selected 'master.svg', it shows latest pull request build status.