### PR TITLE
add go v1.9 for travis, and use latest v1.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: go
 go:
   - 1.6.x
-  - 1.8.3
+  - 1.8.x
+  - 1.9.x
   - tip
 
 go_import_path: go.mercari.io/go-httpdoc


### PR DESCRIPTION
* add v1.9
* make version formats unified so that the latest patched versions are used.
