### PR TITLE
Allow failures for osx with go.1.6.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,20 @@
 language: go
 go:
-  - 1.6.x
   - 1.8.x
   - 1.9.x
   - tip
+
+env:  # need matrix.allow_failures
+
+matrix:
+  include:
+  - os: linux
+    go: 1.6.x
+  - os: osx
+    go: 1.6.x
+  allow_failures:
+  - os: osx
+    go: 1.6.x
 
 go_import_path: go.mercari.io/go-httpdoc
 


### PR DESCRIPTION
Allow failures for osx with `go.1.6.x`.
For no-backward compatibility of gettimeofday syscall on macOS Sierra with go1.6.4.
TravisCI result: https://travis-ci.org/mercari/go-httpdoc/builds/337951269

ref:
- https://docs.travis-ci.com/user/customizing-the-build/#Rows-that-are-Allowed-to-Fail
- https://docs.travis-ci.com/user/multi-os/