### PR TITLE
Stop support Go 1.6.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: go
 go:
-  - 1.6.x
   - 1.8.x
   - 1.9.x
   - tip

--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ See usage and example in [GoDoc](https://godoc.org/go.mercari.io/go-httpdoc).
 
 *NOTE*: This package is experimental and may make backward-incompatible changes.
 
+## Prerequisites
+
+go-httpdoc requires Go 1.7 or later.
+
 ## Install
 
 Use go get:


### PR DESCRIPTION
Remove go `1.6.x` in CI testing. Also, added `Prerequisites` section to README.md.