### PR TITLE
Use pretty.Compare to test equality in tests instead of reflect.DeepEqual

### DIFF
--- a/validate.go
+++ b/validate.go
@@ -5,10 +5,10 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
-	"reflect"
 	"testing"
 
 	"github.com/golang/protobuf/proto"
+	"github.com/kylelemons/godebug/pretty"
 	"github.com/tenntenn/gpath"
 )
 
@@ -16,8 +16,8 @@ var (
 	defaultUnmarshalFunc = json.Unmarshal
 
 	defaultAssertFunc = func(t *testing.T, expected, actual interface{}, desc string) {
-		if !reflect.DeepEqual(expected, actual) {
-			tFatalf(t, "%s: got %#v(%T), want %#v(%T)", desc, actual, actual, expected, expected)
+		if diff := pretty.Compare(actual, expected); diff != "" {
+			tFatalf(t, "%s: (-got +want): \n%s", desc, diff)
 		}
 	}
 

--- a/validate_test.go
+++ b/validate_test.go
@@ -403,7 +403,7 @@ func TestAssertFunc(t *testing.T) {
 	var buf bytes.Buffer
 	tFatalf = fprintFatalFunc(&buf)
 	defaultAssertFunc(t, 1, 2, "test-assert")
-	if got, want := buf.String(), "test-assert: got 2(int), want 1(int)"; !strings.Contains(got, want) {
+	if got, want := buf.String(), "test-assert: (-got +want): \n-2\n+1"; !strings.Contains(got, want) {
 		t.Fatalf("expect %q to contain %q", got, want)
 	}
 


### PR DESCRIPTION
Using `reflect.DeepEqual` dumps the got and expected in a single line and makes it hard to see the actual difference. Whereas, using `pretty.Compare` shows a concise easy to read diff of actual vs. expected.